### PR TITLE
Twinsanity VIF Compiler

### DIFF
--- a/TT Lab/AssetData/Graphics/ModelData.cs
+++ b/TT Lab/AssetData/Graphics/ModelData.cs
@@ -55,6 +55,10 @@ namespace TT_Lab.AssetData.Graphics
                         mesh.Vertices.Add(new Vector3D(ver.Position.X, ver.Position.Y, ver.Position.Z));
                         mesh.TextureCoordinateChannels[0].Add(new Vector3D(ver.UV.X, ver.UV.Y, 1.0f));
                         mesh.VertexColorChannels[0].Add(new Color4D(ver.Color.X, ver.Color.Y, ver.Color.Z, ver.Color.W));
+                        if (ver.HasNormals)
+                        {
+                            mesh.Normals.Add(new Vector3D(ver.Normal.X, ver.Normal.Y, ver.Normal.Z));
+                        }
                     }
                     foreach (var face in faces)
                     {
@@ -85,18 +89,23 @@ namespace TT_Lab.AssetData.Graphics
         {
             Vertexes.Clear();
             Faces.Clear();
-            AssimpContext context = new AssimpContext();
+            AssimpContext context = new();
             var scene = context.ImportFile(dataPath);
             foreach (var mesh in scene.Meshes)
             {
                 var submodel = new List<Vertex>();
                 for (var i = 0; i < mesh.VertexCount; ++i)
                 {
-                    submodel.Add(new Vertex(
+                    var ver = new Vertex(
                         new Vector4(mesh.Vertices[i].X, mesh.Vertices[i].Y, mesh.Vertices[i].Z, 0.0f),
                         new Vector4(mesh.VertexColorChannels[0][i].R, mesh.VertexColorChannels[0][i].G, mesh.VertexColorChannels[0][i].B, mesh.VertexColorChannels[0][i].A),
                         new Vector4(mesh.TextureCoordinateChannels[0][i].X, mesh.TextureCoordinateChannels[0][i].Y, 1.0f, 0.0f)
-                        ));
+                    );
+                    if (mesh.Normals.Count == mesh.Vertices.Count)
+                    {
+                        ver.Normal = new Vector4(mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z, 1.0f);
+                    }
+                    submodel.Add(ver);
                 }
 
                 var faces = new List<IndexedFace>();
@@ -139,15 +148,19 @@ namespace TT_Lab.AssetData.Graphics
                         }
                         ++refIndex;
                     }
-                    var ver = new Vertex(e.Vertexes[j], e.Colors[j], e.UVW[j], e.EmitColor[j])
+                    var ver = new Vertex(e.Vertexes[j], e.Colors[j], e.UVW[j]);
+                    if (e.EmitColor.Count == e.Vertexes.Count)
                     {
-                        Normal = new Vector4(e.Normals[j].X, e.Normals[j].Y, e.Normals[j].Z, e.Normals[j].W)
-                    };
+                        ver.EmitColor = new Vector4(e.EmitColor[j].X, e.EmitColor[j].Y, e.EmitColor[j].Z, e.EmitColor[j].W);
+                    }
+                    if (e.Normals.Count == e.Vertexes.Count)
+                    {
+                        ver.Normal = new Vector4(e.Normals[j].X, e.Normals[j].Y, e.Normals[j].Z, e.Normals[j].W);
+                    }
                     vertList.Add(ver);
                 }
                 Vertexes.Add(vertList);
                 Faces.Add(faceList);
-                //offset += e.Vertexes.Count;
                 refIndex += 2;
             }
         }

--- a/TT Lab/AssetData/Graphics/SubModels/Vertex.cs
+++ b/TT Lab/AssetData/Graphics/SubModels/Vertex.cs
@@ -41,9 +41,21 @@ namespace TT_Lab.AssetData.Graphics.SubModels
         }
         public Vector3 Position { get; set; }
         public Vector4 Color { get; set; }
-        public Vector4 Normal { get; set; }
+        public Vector4 Normal
+        {
+            get => _normal;
+            set
+            {
+                _normal = value;
+                HasNormals = true;
+            }
+        }
         public Vector4 EmitColor { get; set; }
         public Vector3 UV { get; set; }
+
+        public bool HasNormals { get; private set; }
+
+        private Vector4 _normal;
 
         public override String ToString()
         {

--- a/TT Lab/Assets/Factory/PS2ItemFactory.cs
+++ b/TT Lab/Assets/Factory/PS2ItemFactory.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
 using Twinsanity.TwinsanityInterchange.Common.AgentLab;
+using Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.Graphics;
+using Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.RM2.Code;
+using Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.RM2.Layout;
 using Twinsanity.TwinsanityInterchange.Interfaces.Items;
 using Twinsanity.TwinsanityInterchange.Interfaces.Items.RM;
 using Twinsanity.TwinsanityInterchange.Interfaces.Items.RM.Code;
@@ -14,17 +17,26 @@ namespace TT_Lab.Assets.Factory
     {
         public ITwinAIPath GenerateAIPath(Stream stream)
         {
-            throw new NotImplementedException();
+            var aiPath = new PS2AnyAIPath();
+            using var reader = new BinaryReader(stream);
+            aiPath.Read(reader, (Int32)stream.Length);
+            return aiPath;
         }
 
         public ITwinAIPosition GenerateAIPosition(Stream stream)
         {
-            throw new NotImplementedException();
+            var aiPosition = new PS2AnyAIPosition();
+            using var reader = new BinaryReader(stream);
+            aiPosition.Read(reader, (Int32)stream.Length);
+            return aiPosition;
         }
 
         public ITwinAnimation GenerateAnimation(Stream stream)
         {
-            throw new NotImplementedException();
+            var animation = new PS2AnyAnimation();
+            using var reader = new BinaryReader(stream);
+            animation.Read(reader, (Int32)stream.Length);
+            return animation;
         }
 
         public ITwinBehaviour GenerateBehaviour(Stream stream)
@@ -69,7 +81,10 @@ namespace TT_Lab.Assets.Factory
 
         public ITwinInstance GenerateInstance(Stream stream)
         {
-            throw new NotImplementedException();
+            var instance = new PS2AnyInstance();
+            using var reader = new BinaryReader(stream);
+            instance.Read(reader, (Int32)stream.Length);
+            return instance;
         }
 
         public ITwinLink GenerateLink(Stream stream)
@@ -79,17 +94,26 @@ namespace TT_Lab.Assets.Factory
 
         public ITwinLOD GenerateLOD(Stream stream)
         {
-            throw new NotImplementedException();
+            var lod = new PS2AnyLOD();
+            using var reader = new BinaryReader(stream);
+            lod.Read(reader, (Int32)stream.Length);
+            return lod;
         }
 
         public ITwinMaterial GenerateMaterial(Stream stream)
         {
-            throw new NotImplementedException();
+            var material = new PS2AnyMaterial();
+            using var reader = new BinaryReader(stream);
+            material.Read(reader, (Int32)stream.Length);
+            return material;
         }
 
         public ITwinMesh GenerateMesh(Stream stream)
         {
-            throw new NotImplementedException();
+            var mesh = new PS2AnyMesh();
+            using var reader = new BinaryReader(stream);
+            mesh.Read(reader, (Int32)stream.Length);
+            return mesh;
         }
 
         public ITwinModel GenerateModel(Stream stream)
@@ -114,17 +138,26 @@ namespace TT_Lab.Assets.Factory
 
         public ITwinPath GeneratePath(Stream stream)
         {
-            throw new NotImplementedException();
+            var path = new PS2AnyPath();
+            using var reader = new BinaryReader(stream);
+            path.Read(reader, (Int32)stream.Length);
+            return path;
         }
 
         public ITwinPosition GeneratePosition(Stream stream)
         {
-            throw new NotImplementedException();
+            var position = new PS2AnyPosition();
+            using var reader = new BinaryReader(stream);
+            position.Read(reader, (Int32)stream.Length);
+            return position;
         }
 
         public ITwinRigidModel GenerateRigidModel(Stream stream)
         {
-            throw new NotImplementedException();
+            var rigidModel = new PS2AnyRigidModel();
+            using var reader = new BinaryReader(stream);
+            rigidModel.Read(reader, (Int32)stream.Length);
+            return rigidModel;
         }
 
         public ITwinScenery GenerateScenery(Stream stream)
@@ -139,7 +172,10 @@ namespace TT_Lab.Assets.Factory
 
         public ITwinSkydome GenerateSkydome(Stream stream)
         {
-            throw new NotImplementedException();
+            var skydome = new PS2AnySkydome();
+            using var reader = new BinaryReader(stream);
+            skydome.Read(reader, (Int32)stream.Length);
+            return skydome;
         }
 
         public ITwinSound GenerateSound(Stream stream)
@@ -149,12 +185,18 @@ namespace TT_Lab.Assets.Factory
 
         public ITwinSurface GenerateSurface(Stream stream)
         {
-            throw new NotImplementedException();
+            var surface = new PS2AnyCollisionSurface();
+            using var reader = new BinaryReader(stream);
+            surface.Read(reader, (Int32)stream.Length);
+            return surface;
         }
 
         public ITwinTemplate GenerateTemplate(Stream stream)
         {
-            throw new NotImplementedException();
+            var template = new PS2AnyTemplate();
+            using var reader = new BinaryReader(stream);
+            template.Read(reader, (Int32)stream.Length);
+            return template;
         }
 
         public ITwinTexture GenerateTexture(Stream stream)
@@ -164,7 +206,10 @@ namespace TT_Lab.Assets.Factory
 
         public ITwinTrigger GenerateTrigger(Stream stream)
         {
-            throw new NotImplementedException();
+            var trigger = new PS2AnyTrigger();
+            using var reader = new BinaryReader(stream);
+            trigger.Read(reader, (Int32)stream.Length);
+            return trigger;
         }
     }
 }

--- a/TwinTech/PS2Hardware/DMATag.cs
+++ b/TwinTech/PS2Hardware/DMATag.cs
@@ -7,7 +7,7 @@ namespace Twinsanity.PS2Hardware
     {
         public UInt16 QWC;
         public Byte PCE;
-        public Byte ID;
+        public IdType ID;
         public Byte IRQ;
         public UInt32 ADDR;
         public Byte SPR;
@@ -17,7 +17,7 @@ namespace Twinsanity.PS2Hardware
             var low = reader.ReadUInt64();
             QWC = (UInt16)(low & 0xFFFF);
             PCE = (Byte)(low >> 26 & 0b11);
-            ID = (Byte)(low >> 28 & 0b111);
+            ID = (IdType)(low >> 28 & 0b111);
             IRQ = (Byte)(low >> 31 & 0b1);
             ADDR = (UInt32)(low >> 32 & 0x7FFFFFFF);
             SPR = (Byte)(low >> 63 & 0b1);
@@ -34,6 +34,18 @@ namespace Twinsanity.PS2Hardware
             low |= (UInt64)SPR << 63;
             writer.Write(low);
             writer.Write(Extra);
+        }
+
+        public enum IdType
+        {
+            REFE = 0b000,
+            CNT = 0b001,
+            NEXT = 0b010,
+            REF = 0b011,
+            REFS = 0b100,
+            CALL = 0b101,
+            RET = 0b110,
+            END = 0b111
         }
     }
 }

--- a/TwinTech/PS2Hardware/TwinVIFCompiler.cs
+++ b/TwinTech/PS2Hardware/TwinVIFCompiler.cs
@@ -371,14 +371,14 @@ namespace Twinsanity.PS2Hardware
                                 var uv = vectorBatch[GetBatchIndex(VectorBatchIndex.Uv)][j];
                                 var compiledPosition = position.Divide(scaleVector.X);
                                 var compiledUv = uv.Divide(scaleVector.Y);
-                                compiledPosition.SetBinaryX((UInt32)((Int32)compiledPosition.X));
-                                compiledPosition.SetBinaryY((UInt32)((Int32)compiledPosition.Y));
-                                compiledPosition.SetBinaryZ((UInt32)((Int32)compiledPosition.Z));
-                                compiledPosition.SetBinaryW((UInt32)((Int32)compiledPosition.W));
-                                compiledUv.SetBinaryX((UInt32)((Int32)compiledUv.X));
-                                compiledUv.SetBinaryY((UInt32)((Int32)compiledUv.Y));
-                                compiledUv.SetBinaryZ((UInt32)((Int32)compiledUv.Z));
-                                compiledUv.SetBinaryW((UInt32)((Int32)compiledUv.W));
+                                compiledPosition.SetBinaryX((UInt32)((Int16)compiledPosition.X));
+                                compiledPosition.SetBinaryY((UInt32)((Int16)compiledPosition.Y));
+                                compiledPosition.SetBinaryZ((UInt32)((Int16)compiledPosition.Z));
+                                compiledPosition.SetBinaryW((UInt32)((Int16)compiledPosition.W));
+                                compiledUv.SetBinaryX((UInt32)((Int16)compiledUv.X));
+                                compiledUv.SetBinaryY((UInt32)((Int16)compiledUv.Y));
+                                compiledUv.SetBinaryZ((UInt32)((Int16)compiledUv.Z));
+                                compiledUv.SetBinaryW((UInt32)((Int16)compiledUv.W));
                                 compiledPositions.Add(compiledPosition);
                                 compiledUvs.Add(compiledUv);
                             }

--- a/TwinTech/PS2Hardware/TwinVIFCompiler.cs
+++ b/TwinTech/PS2Hardware/TwinVIFCompiler.cs
@@ -549,7 +549,7 @@ namespace Twinsanity.PS2Hardware
 
             // Create new batch
             swizzledVectorBatches = new();
-            for (Int32 i = 0; i < swizzleCount - 1; i++)
+            for (Int32 i = 0; i < swizzleCount; i++)
             {
                 // Create new list for the batch
                 swizzledVectorBatches.Add(new());
@@ -567,8 +567,8 @@ namespace Twinsanity.PS2Hardware
                     {
                         swizzledVectorBatches[^1][k].Add(vectorData[k][vertexIndex + j]);
                     }
-                    vertexIndex++;
                 }
+                vertexIndex += swizzleAmount;
             }
 
             // Fill the leftover batch
@@ -589,7 +589,6 @@ namespace Twinsanity.PS2Hardware
                 {
                     swizzledVectorBatches[^1][k].Add(vectorData[k][vertexIndex + j]);
                 }
-                vertexIndex++;
             }
         }
     }

--- a/TwinTech/PS2Hardware/TwinVIFCompiler.cs
+++ b/TwinTech/PS2Hardware/TwinVIFCompiler.cs
@@ -266,11 +266,11 @@ namespace Twinsanity.PS2Hardware
                                 // Undo the reversing of UV
                                 uv.Y = 1 - uv.Y;
                                 var compiledVector = new Vector4();
-                                compiledVector.SetBinaryX(uv.GetBinaryX() | color.R);
-                                compiledVector.SetBinaryY(uv.GetBinaryY() | color.G);
+                                compiledVector.SetBinaryX((uv.GetBinaryX() & 0xFFFFFF00) | color.R);
+                                compiledVector.SetBinaryY((uv.GetBinaryY() & 0xFFFFFF00) | color.G);
                                 // Redo it back to make sure we are not modifying the input vector
                                 uv.Y = 1 - uv.Y;
-                                compiledVector.SetBinaryZ(uv.GetBinaryZ() | color.B);
+                                compiledVector.SetBinaryZ((uv.GetBinaryZ() & 0xFFFFFF00) | color.B);
                                 compiledVector.SetBinaryW(color.A | (UInt32)(conns[connIndex++] ? 0x0 : 0x8000));
                                 resultBatch.Add(compiledVector);
                             }

--- a/TwinTech/PS2Hardware/TwinVIFCompiler.cs
+++ b/TwinTech/PS2Hardware/TwinVIFCompiler.cs
@@ -1,0 +1,590 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Twinsanity.TwinsanityInterchange.Common;
+
+
+namespace Twinsanity.PS2Hardware
+{
+    using SwizzledVectorData = List<List<List<Vector4>>>;
+
+
+    public class TwinVIFCompiler
+    {
+
+        private readonly ModelType type;
+        private readonly List<List<Vector4>> vectorData;
+        private readonly List<bool> conns;
+        private SwizzledVectorData swizzledVectorBatches;
+        private readonly Dictionary<ModelType, List<UInt16>> outputAddressMap = new()
+        {
+            {
+                ModelType.Model, new List<UInt16> { 0, 1, 3, 4, 5, 6 }
+            },
+            {
+                ModelType.Skin, new List<UInt16> { 0, 1, 2, 3, 4, 6, 5 }
+            },
+            {
+                ModelType.BlendSkin, new List<UInt16> { 0, 1, 2, 3, 4, 6, 5 }
+            }
+        };
+
+        private enum VectorBatchIndex
+        {
+            Vertex,
+            Color,
+            Uv,
+            Normal,
+            EmitColor,
+            JointInfo
+        }
+
+        public enum ModelType
+        {
+            Model,
+            Skin,
+            BlendSkin,
+            BlendFace
+        }
+
+        public TwinVIFCompiler(ModelType type, List<List<Vector4>> data, List<bool> conns)
+        {
+            this.type = type;
+            this.vectorData = data;
+            this.conns = conns;
+        }
+
+        public Byte[] Compile()
+        {
+            var interpreter = new VIFInterpreter();
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+
+            // Blend faces are special in that they are pure packed vector data
+            if (type == ModelType.BlendFace)
+            {
+                var packedFaceData = new List<UInt32>();
+                interpreter.Pack(vectorData[0], packedFaceData, PackFormat.V4_8);
+                foreach (var packedFace in packedFaceData)
+                {
+                    writer.Write(packedFace);
+                }
+                var spaceNeeded = packedFaceData.Sum(_ => 4);
+                while (spaceNeeded % 0x10 != 0)
+                {
+                    writer.Write(0U);
+                    spaceNeeded += 4;
+                }
+
+                writer.Flush();
+                ms.Flush();
+                return ms.ToArray();
+            }
+            
+            var dmaTag = new DMATag
+            {
+                ID = DMATag.IdType.RET // Indicates that all transfered data is right next to the DMA tag
+            };
+            dmaTag.Extra |= 0x00000000070000fa; // The entry is a VIF command called MARK with a value of 0xFA/250
+            dmaTag.QWC = 0;
+            var dmaTagPosition = writer.BaseStream.Position; // Return at the end to rewrite the amount of QWC in DMA tag
+            dmaTag.Write(writer);
+
+            // After MASK comes a NOP operation for alignment
+            VIFCode nop = new()
+            {
+                OP = VIFCodeEnum.NOP
+            };
+            nop.Write(writer);
+
+            // Swizzle the vector data and go over every batch compiling it into its needed format
+            var totalSpaceNeeded = nop.GetLength();
+            var connIndex = 0;
+            SwizzleVectorData();
+            for (Int32 i = 0; i < swizzledVectorBatches.Count; i++)
+            {
+                var vectorBatch = swizzledVectorBatches[i];
+                var outAddressIndex = 0;
+                // Next up is the model descriptor which tells what the format of the model is
+                VIFCode modelDescriptorCode = new()
+                {
+                    OP = VIFCodeEnum.UNPACK,
+                    Immediate = outputAddressMap[type][outAddressIndex++],
+                    Amount = 1
+                };
+                modelDescriptorCode.SetUnpackFormat(PackFormat.V4_32);
+                modelDescriptorCode.Write(writer);
+                var packedMetaVector = new List<UInt32>();
+                var modelDescriptor = new Vector4();
+                // A GIF tag describing what GS registers to set when sending the model data to GS
+                modelDescriptor.SetBinaryX(0x8000 | (UInt32)vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count); // Set End of packet flag and the amount of loops
+                modelDescriptor.SetBinaryY(0x30024000); // Set primitive as triangle strip in PACKED mode with 3 descriptors
+                modelDescriptor.SetBinaryZ(0x512); // Use REGS ST, RGBAQ and XYZ2 (in that exact order) as GS outputs
+                modelDescriptor.SetBinaryW(0x0);
+                var metaVectorList = new List<Vector4>
+                {
+                    modelDescriptor
+                };
+                interpreter.Pack(metaVectorList, packedMetaVector, PackFormat.V4_32);
+                foreach (var packedV in packedMetaVector)
+                {
+                    writer.Write(packedV);
+                }
+                totalSpaceNeeded += modelDescriptorCode.GetLength();
+
+                // After comes STCYCL operation
+                VIFCode setCycle = new()
+                {
+                    OP = VIFCodeEnum.STCYCL,
+                    Immediate = 0x0101
+                };
+                setCycle.Write(writer);
+                totalSpaceNeeded += setCycle.GetLength();
+
+                // Next up is the meta data vector packed as V2_32. Purpose unknown
+                VIFCode metaVectorCode = new()
+                {
+                    OP = VIFCodeEnum.UNPACK,
+                    Immediate = outputAddressMap[type][outAddressIndex++],
+                    Amount = 1
+                };
+                metaVectorCode.SetUnpackFormat(PackFormat.V2_32);
+                metaVectorCode.Write(writer);
+                packedMetaVector.Clear();
+                var metaVector = new Vector4();
+                metaVector.SetBinaryX((UInt32)vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count * 4);
+                metaVector.SetBinaryY(0x8000 | (UInt32)vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count);
+                metaVectorList.Clear();
+                metaVectorList.Add(metaVector);
+                interpreter.Pack(metaVectorList, packedMetaVector, PackFormat.V2_32);
+                foreach (var packedV in packedMetaVector)
+                {
+                    writer.Write(packedV);
+                }
+                totalSpaceNeeded += metaVectorCode.GetLength();
+
+                // Scale vector for Twinsanity's skins and blend skins
+                // This is mostly correct and what most skins use in Twinsanity but maybe there is some magic to figure this out?
+                var scaleVector = new Vector4();
+                scaleVector.SetBinaryX(0x38C03F4D);
+                scaleVector.SetBinaryY(0x3A000000);
+
+                // For skins and blend skins a special scaling vector comes in
+                if (type == ModelType.Skin || type == ModelType.BlendSkin)
+                {
+                    VIFCode scaleVectorCode = new()
+                    {
+                        OP = VIFCodeEnum.UNPACK,
+                        Immediate = outputAddressMap[type][outAddressIndex++],
+                        Amount = 1
+                    };
+                    scaleVectorCode.SetUnpackFormat(PackFormat.V2_32);
+                    scaleVectorCode.Write(writer);
+                    var packedScaleVector = new List<UInt32>();
+                    var scaleVectorList = new List<Vector4>
+                    {
+                        scaleVector
+                    };
+                    interpreter.Pack(scaleVectorList, packedScaleVector, PackFormat.V2_32);
+                    foreach (var packedV in packedScaleVector)
+                    {
+                        writer.Write(packedV);
+                    }
+                    totalSpaceNeeded += scaleVectorCode.GetLength();
+
+                    // Additionally add in STMOD and STROW to sets additional decompression write
+                    VIFCode turnOnOffsetCode = new()
+                    {
+                        OP = VIFCodeEnum.STMOD,
+                        Immediate = 0x0001
+                    };
+                    turnOnOffsetCode.Write(writer);
+                    totalSpaceNeeded += turnOnOffsetCode.GetLength();
+
+                    // Still not entirely sure how Twinsanity needs this or how to even calculate the values but stays here for now
+                    VIFCode setRow = new()
+                    {
+                        OP = VIFCodeEnum.STROW,
+                        Immediate = 0
+                    };
+                    setRow.Write(writer);
+                    writer.Write(0U);
+                    writer.Write(0U);
+                    writer.Write(0U);
+                    writer.Write(0U);
+                    totalSpaceNeeded += setRow.GetLength();
+                }
+
+                // Next up is STCYCL operation again
+                setCycle = new()
+                {
+                    OP = VIFCodeEnum.STCYCL,
+                    Immediate = 0x0104
+                };
+                setCycle.Write(writer);
+
+                // After comes the actual writing of vectors
+                switch (type)
+                {
+                    // For models there are Vertexes, UVs + Colors + Conns, Normals(optional) and EmitColors(optional)
+                    case ModelType.Model:
+                        {
+                            var hasNormals = vectorData.Count == 5;
+                            var hasEmitColors = vectorData.Count >= 4;
+
+                            // Write vertexes
+                            VIFCode vertexCode = new()
+                            {
+                                OP = VIFCodeEnum.UNPACK,
+                                Immediate = outputAddressMap[type][outAddressIndex++],
+                                Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count
+                            };
+                            vertexCode.SetUnpackFormat(PackFormat.V3_32);
+                            vertexCode.Write(writer);
+                            var packedVertexData = new List<UInt32>();
+                            interpreter.Pack(vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)], packedVertexData, PackFormat.V3_32);
+                            foreach (var packedVertex in packedVertexData)
+                            {
+                                writer.Write(packedVertex);
+                            }
+                            totalSpaceNeeded += vertexCode.GetLength();
+
+                            // Compile the resulting UVs + Colors + Conns
+                            var colors = vectorBatch[GetBatchIndex(VectorBatchIndex.Color)].Select(c => c.GetColor()).ToList();
+                            var uvs = vectorBatch[GetBatchIndex(VectorBatchIndex.Uv)];
+                            var resultBatch = new List<Vector4>(colors.Count);
+                            for (Int32 j = 0; j < colors.Count; j++)
+                            {
+                                var color = colors[j];
+                                color.ScaleAlphaDown();
+                                var uv = uvs[j];
+                                // Undo the reversing of UV
+                                uv.Y = 1 - uv.Y;
+                                var compiledVector = new Vector4();
+                                compiledVector.SetBinaryX(uv.GetBinaryX() | color.R);
+                                compiledVector.SetBinaryY(uv.GetBinaryY() | color.G);
+                                // Redo it back to make sure we are not modifying the input vector
+                                uv.Y = 1 - uv.Y;
+                                compiledVector.SetBinaryZ(uv.GetBinaryZ() | color.B);
+                                compiledVector.SetBinaryW(color.A | (UInt32)(conns[connIndex++] ? 0x8000 : 0x0));
+                                resultBatch.Add(compiledVector);
+                            }
+
+                            // Write UVs + Colors + Conns
+                            VIFCode uvColorCode = new()
+                            {
+                                OP = VIFCodeEnum.UNPACK,
+                                Immediate = outputAddressMap[type][outAddressIndex++],
+                                Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.Uv)].Count
+                            };
+                            uvColorCode.SetUnpackFormat(PackFormat.V4_32);
+                            uvColorCode.Write(writer);
+                            var packedUvColorData = new List<UInt32>();
+                            interpreter.Pack(resultBatch, packedUvColorData, PackFormat.V4_32);
+                            foreach (var packedUvColor in packedUvColorData)
+                            {
+                                writer.Write(packedUvColor);
+                            }
+                            totalSpaceNeeded += uvColorCode.GetLength();
+
+                            // Write normals if any
+                            if (hasNormals)
+                            {
+                                VIFCode normalsCode = new()
+                                {
+                                    OP = VIFCodeEnum.UNPACK,
+                                    Immediate = outputAddressMap[type][outAddressIndex],
+                                    Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.Normal)].Count
+                                };
+                                normalsCode.SetUnpackFormat(PackFormat.V3_32);
+                                normalsCode.Write(writer);
+                                var packedNormals = new List<UInt32>();
+                                interpreter.Pack(vectorBatch[GetBatchIndex(VectorBatchIndex.Normal)], packedNormals, PackFormat.V3_32);
+                                foreach (var packedNormal in packedNormals)
+                                {
+                                    writer.Write(packedNormal);
+                                }
+                                totalSpaceNeeded += normalsCode.GetLength();
+                            }
+                            // Increment output address index regardless if normals were present
+                            outAddressIndex++;
+
+                            // Write emit colors if any
+                            if (hasEmitColors)
+                            {
+                                VIFCode emitColorsCode = new()
+                                {
+                                    OP = VIFCodeEnum.UNPACK,
+                                    Immediate = outputAddressMap[type][outAddressIndex],
+                                    Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.EmitColor)].Count
+                                };
+                                emitColorsCode.SetUnpackFormat(PackFormat.V4_8);
+                                emitColorsCode.Write(writer);
+                                var packedEmits = new List<UInt32>();
+                                interpreter.Pack(vectorBatch[GetBatchIndex(VectorBatchIndex.EmitColor)], packedEmits, PackFormat.V4_8);
+                                foreach (var emits in packedEmits)
+                                {
+                                    writer.Write(emits);
+                                }
+                                totalSpaceNeeded += emitColorsCode.GetLength();
+                            }
+                            // Increment output address index regardless if emit colors were present
+                            outAddressIndex++;
+                        }
+                        break;
+                    // For skins and blend skins there are Vertexes, UVs, Colors, Joint information + Conns
+                    case ModelType.Skin:
+                    case ModelType.BlendSkin:
+                        {
+                            // Compile vertexes and UVs
+                            var compiledPositions = new List<Vector4>(vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count);
+                            var compiledUvs = new List<Vector4>(vectorBatch[GetBatchIndex(VectorBatchIndex.Uv)].Count);
+                            for (Int32 j = 0; j < vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count; j++)
+                            {
+                                var position = vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)][j];
+                                var uv = vectorBatch[GetBatchIndex(VectorBatchIndex.Uv)][j];
+                                var compiledPosition = position.Divide(scaleVector.X);
+                                var compiledUv = uv.Divide(scaleVector.Y);
+                                compiledPosition.SetBinaryX((UInt32)((Int32)compiledPosition.X));
+                                compiledPosition.SetBinaryY((UInt32)((Int32)compiledPosition.Y));
+                                compiledPosition.SetBinaryZ((UInt32)((Int32)compiledPosition.Z));
+                                compiledPosition.SetBinaryW((UInt32)((Int32)compiledPosition.W));
+                                compiledUv.SetBinaryX((UInt32)((Int32)compiledUv.X));
+                                compiledUv.SetBinaryY((UInt32)((Int32)compiledUv.Y));
+                                compiledUv.SetBinaryZ((UInt32)((Int32)compiledUv.Z));
+                                compiledUv.SetBinaryW((UInt32)((Int32)compiledUv.W));
+                                compiledPositions.Add(compiledPosition);
+                                compiledUvs.Add(compiledUv);
+                            }
+
+                            // Write vertexes
+                            VIFCode vertexCode = new()
+                            {
+                                OP = VIFCodeEnum.UNPACK,
+                                Immediate = outputAddressMap[type][outAddressIndex++],
+                                Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.Vertex)].Count
+                            };
+                            vertexCode.SetUnpackFormat(PackFormat.V4_16);
+                            vertexCode.Write(writer);
+                            var packedVertexData = new List<UInt32>();
+                            interpreter.Pack(compiledPositions, packedVertexData, PackFormat.V4_16);
+                            foreach (var packedVertex in packedVertexData)
+                            {
+                                writer.Write(packedVertex);
+                            }
+                            totalSpaceNeeded += vertexCode.GetLength();
+
+                            // Set row to all 0s
+                            VIFCode setRow = new()
+                            {
+                                OP = VIFCodeEnum.STROW,
+                                Immediate = 0
+                            };
+                            setRow.Write(writer);
+                            writer.Write(0U);
+                            writer.Write(0U);
+                            writer.Write(0U);
+                            writer.Write(0U);
+                            totalSpaceNeeded += setRow.GetLength();
+
+                            // Write UVs
+                            VIFCode uvCode = new()
+                            {
+                                OP = VIFCodeEnum.UNPACK,
+                                Immediate = outputAddressMap[type][outAddressIndex++],
+                                Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.Uv)].Count
+                            };
+                            uvCode.SetUnpackFormat(PackFormat.V4_16);
+                            uvCode.Write(writer);
+                            var packedUvData = new List<UInt32>();
+                            interpreter.Pack(compiledUvs, packedUvData, PackFormat.V4_16);
+                            foreach (var packedUv in packedUvData)
+                            {
+                                writer.Write(packedUv);
+                            }
+                            totalSpaceNeeded += uvCode.GetLength();
+
+                            // Turn off the offset mode
+                            VIFCode turnOffOffsetCode = new()
+                            {
+                                OP = VIFCodeEnum.STMOD,
+                                Immediate = 0x0000
+                            };
+                            turnOffOffsetCode.Write(writer);
+                            totalSpaceNeeded += turnOffOffsetCode.GetLength();
+
+                            // Compile colors
+                            var colors = vectorBatch[GetBatchIndex(VectorBatchIndex.Color)].Select(c => c.GetColor()).Select(c =>
+                            {
+                                c.ScaleAlphaDown();
+                                return c;
+                            }).ToList();
+                            var compiledColors = new List<Vector4>(colors.Count);
+                            foreach (var c in colors)
+                            {
+                                var compiledColor = new Vector4();
+                                compiledColor.SetBinaryX(c.R);
+                                compiledColor.SetBinaryY(c.G);
+                                compiledColor.SetBinaryZ(c.B);
+                                compiledColor.SetBinaryW(c.A);
+                                compiledColors.Add(compiledColor);
+                            }
+
+                            // Write colors
+                            VIFCode colorCode = new()
+                            {
+                                OP = VIFCodeEnum.UNPACK,
+                                Immediate = outputAddressMap[type][outAddressIndex++],
+                                Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.Color)].Count
+                            };
+                            colorCode.SetUnpackFormat(PackFormat.V4_8);
+                            colorCode.Write(writer);
+                            var packedColorsData = new List<UInt32>();
+                            interpreter.Pack(compiledColors, packedColorsData, PackFormat.V4_8);
+                            foreach (var packedColor in packedColorsData)
+                            {
+                                writer.Write(packedColor);
+                            }
+                            totalSpaceNeeded += colorCode.GetLength();
+
+                            // Write joint information
+                            VIFCode jointCode = new()
+                            {
+                                OP = VIFCodeEnum.UNPACK,
+                                Immediate = outputAddressMap[type][outAddressIndex++],
+                                Amount = (Byte)vectorBatch[GetBatchIndex(VectorBatchIndex.JointInfo)].Count
+                            };
+                            jointCode.SetUnpackFormat(PackFormat.V4_32);
+                            jointCode.Write(writer);
+                            var packedJointData = new List<UInt32>();
+                            interpreter.Pack(vectorBatch[GetBatchIndex(VectorBatchIndex.JointInfo)], packedJointData, PackFormat.V4_32);
+                            foreach (var packedJoint in packedJointData)
+                            {
+                                writer.Write(packedJoint);
+                            }
+                            totalSpaceNeeded += jointCode.GetLength();
+                        }
+                        break;
+                    default:
+                        throw new Exception("Unexisting model type provided");
+                }
+
+                VIFCode mscal = new()
+                {
+                    OP = VIFCodeEnum.MSCAL,
+                    Immediate = 0x0
+                };
+                mscal.Write(writer);
+                totalSpaceNeeded += mscal.GetLength();
+
+                setCycle = new()
+                {
+                    OP = VIFCodeEnum.STCYCL,
+                    Immediate = 0x0101
+                };
+                setCycle.Write(writer);
+                totalSpaceNeeded += setCycle.GetLength();
+            }
+
+            // Align to 16(0x10) bytes
+            while (totalSpaceNeeded % 0x10 != 0)
+            {
+                nop.Write(writer);
+                totalSpaceNeeded += nop.GetLength();
+            }
+
+            // As a cherry on top tell DMA tag how many QWCs we are gonna transfer
+            dmaTag.QWC = (UInt16)(totalSpaceNeeded / 0x10);
+            writer.BaseStream.Position = dmaTagPosition;
+            dmaTag.Write(writer);
+
+            // Finally flush all the operations and return the byte code compiled model
+            writer.Flush();
+            ms.Flush();
+            return ms.ToArray();
+        }
+
+        private Int32 GetBatchIndex(VectorBatchIndex index)
+        {
+            return type switch
+            {
+                ModelType.Model => index switch
+                {
+                    VectorBatchIndex.JointInfo => throw new NotImplementedException(),
+                    _ => (Int32)index
+                },
+                ModelType.Skin or ModelType.BlendSkin => index switch
+                {
+                    VectorBatchIndex.Vertex => (Int32)index,
+                    VectorBatchIndex.Color => 2,
+                    VectorBatchIndex.Uv => 1,
+                    VectorBatchIndex.JointInfo => 3,
+                    _ => throw new NotImplementedException()
+                },
+                _ => throw new NotImplementedException()
+            };
+        }
+
+        private void SwizzleVectorData()
+        {
+            var vertexAmount = vectorData[0].Count;
+            Debug.Assert(vectorData.All(l => l.Count == vertexAmount), "Must swizzle equal amount of vertexes");
+            // TODO: Better swizzling heuristic
+            var swizzleAmount = 37;
+            var vertexIndex = 0;
+            var leftOver = vertexAmount % swizzleAmount;
+            var swizzleCount = vertexAmount / swizzleAmount;
+
+            // Create new batch
+            swizzledVectorBatches = new();
+            for (Int32 i = 0; i < swizzleCount; i++)
+            {
+                // Create new list for the batch
+                swizzledVectorBatches.Add(new());
+
+                // Create new list for each type of vertex data
+                for (Int32 j = 0; j < vectorData.Count; j++)
+                {
+                    swizzledVectorBatches[^1].Add(new());
+                }
+
+                // Fill the batch with each vertex type
+                for (Int32 j = 0; j < swizzleAmount; j++)
+                {
+                    for (Int32 k = 0; k < vectorData.Count; k++)
+                    {
+                        swizzledVectorBatches[^1][k].Add(vectorData[k][vertexIndex + j]);
+                    }
+                    vertexIndex++;
+                }
+            }
+
+            // Fill the leftover batch
+            for (Int32 i = 0; i < leftOver; ++i)
+            {
+                // Create new list for the batch
+                swizzledVectorBatches.Add(new());
+
+                // Create new list for each type of vertex data
+                for (Int32 j = 0; j < vectorData.Count; j++)
+                {
+                    swizzledVectorBatches[^1].Add(new());
+                }
+
+                // Fill the batch with each vertex type
+                for (Int32 j = 0; j < swizzleAmount; j++)
+                {
+                    for (Int32 k = 0; k < vectorData.Count; k++)
+                    {
+                        swizzledVectorBatches[^1][k].Add(vectorData[k][vertexIndex + j]);
+                    }
+                    vertexIndex++;
+                }
+            }
+        }
+    }
+}

--- a/TwinTech/PS2Hardware/VIFCode.cs
+++ b/TwinTech/PS2Hardware/VIFCode.cs
@@ -40,6 +40,18 @@ namespace Twinsanity.PS2Hardware
             return (UInt32)CMD << 24 | (UInt32)Amount << 16 | (UInt32)Immediate << 0;
         }
 
+        public void SetUnpackAddressMode(bool set)
+        {
+            Debug.Assert(IsUnpack(), "VIF Code must be in unpack mode for this operation");
+            if (set)
+            {
+                Immediate |= (1 << 15);
+                return;
+            }
+
+            Immediate &= unchecked((UInt16)(~(1U << 15)));
+        }
+
         public bool IsUnpack()
         {
             return (OP & VIFCodeEnum.UNPACK) == VIFCodeEnum.UNPACK;

--- a/TwinTech/PS2Hardware/VIFInterpreter.cs
+++ b/TwinTech/PS2Hardware/VIFInterpreter.cs
@@ -31,35 +31,26 @@ namespace Twinsanity.PS2Hardware
         // Wrapper function for generating Interpreter instances
         public static VIFInterpreter InterpretCode(BinaryReader reader)
         {
-            DMATag tag = new DMATag();
+            DMATag tag = new();
             tag.Read(reader);
-            using (var mem = new MemoryStream())
-            using (var writer = new BinaryWriter(mem))
-            {
-                // Transfer tag's extra data and its QWC data to VIF
-                writer.Write(tag.Extra);
-                writer.Write(reader.ReadBytes(tag.QWC * 0x10));
-                mem.Position = 0;
-                using (var vifReader = new BinaryReader(mem))
-                {
-                    var vifCode = new VIFInterpreter();
-                    vifCode.Execute(vifReader);
-                    return vifCode;
-                }
-            }
+            using var mem = new MemoryStream();
+            using var writer = new BinaryWriter(mem);
+            // Transfer tag's extra data and its QWC data to VIF
+            writer.Write(tag.Extra);
+            writer.Write(reader.ReadBytes(tag.QWC * 0x10));
+            mem.Position = 0;
+            using var vifReader = new BinaryReader(mem);
+            var vifCode = new VIFInterpreter();
+            vifCode.Execute(vifReader);
+            return vifCode;
         }
 
         // Wrapper function for generating Interpreter instances using pure bytecode
         public static VIFInterpreter InterpretCode(Byte[] code)
         {
-            using (MemoryStream codeStr = new MemoryStream(code))
-            {
-                using (BinaryReader codeReader = new BinaryReader(codeStr))
-                {
-                    return InterpretCode(codeReader);
-                }
-            }
-
+            using MemoryStream codeStr = new(code);
+            using BinaryReader codeReader = new(codeStr);
+            return InterpretCode(codeReader);
         }
 
         public List<List<Vector4>> GetMem()
@@ -86,9 +77,9 @@ namespace Twinsanity.PS2Hardware
         {
             while (reader.BaseStream.Position < reader.BaseStream.Length)
             {
-                VIFCode vif = new VIFCode();
+                VIFCode vif = new();
                 vif.Read(reader);
-                if (vif.isUnpack())
+                if (vif.IsUnpack())
                 {
                     Byte cmd = (Byte)vif.OP;
                     Byte vn = (Byte)((cmd & 0b1100) >> 2);
@@ -103,8 +94,8 @@ namespace Twinsanity.PS2Hardware
                     UInt32 dimensions = (UInt32)(vn + 1);
                     UInt32 packet_length = 0;
                     Boolean fill = WL > CL;
-                    Console.WriteLine($"Total cycle specifier {CL}");
-                    Console.WriteLine($"Write cycle specifier {WL}");
+                    Console.WriteLine($"Total per cycle {CL}");
+                    Console.WriteLine($"Write per cycle {WL}");
                     if (!fill)
                     {
                         UInt32 a = (UInt32)(32 >> vl);
@@ -217,7 +208,7 @@ namespace Twinsanity.PS2Hardware
                             int len = 0;
                             do
                             {
-                                GIFTag tag = new GIFTag();
+                                GIFTag tag = new();
                                 tag.Read(reader);
                                 GifBuffer.Add(tag);
                                 flag = tag.EOP != 1;
@@ -243,7 +234,7 @@ namespace Twinsanity.PS2Hardware
             n = ((n & 0x80) != 0) ? n | 0xFFFFFF00 : n;
         }
 
-        private void Unpack(List<UInt32> src, List<Vector4> dst, PackFormat fmt, Byte amount, Byte unsigned, Boolean fill, Byte write, Byte cycle, UInt16 addr)
+        public void Unpack(List<UInt32> src, List<Vector4> dst, PackFormat fmt, Byte amount, Byte unsigned, Boolean fill, Byte write, Byte cycle, UInt16 addr)
         {
             var srcIdx = 0;
             switch (fmt)
@@ -558,7 +549,7 @@ namespace Twinsanity.PS2Hardware
             }
         }
 
-        private void Pack(List<Vector4> src, List<UInt32> dst, PackFormat fmt)
+        public void Pack(List<Vector4> src, List<UInt32> dst, PackFormat fmt)
         {
             UInt32 resUInt = 0;
             switch (fmt)

--- a/TwinTech/TwinsanityInterchange/Common/Vector4.cs
+++ b/TwinTech/TwinsanityInterchange/Common/Vector4.cs
@@ -26,6 +26,15 @@ namespace Twinsanity.TwinsanityInterchange.Common
             this.Z = Z;
             this.W = W;
         }
+
+        public Vector4(Vector3 pos, float W)
+        {
+            this.X = pos.X;
+            this.Y = pos.Y;
+            this.Z = pos.Z;
+            this.W = W;
+        }
+
         public Vector4(Vector4 other)
         {
             X = other.X;

--- a/TwinTech/TwinsanityInterchange/Common/Vector4.cs
+++ b/TwinTech/TwinsanityInterchange/Common/Vector4.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Twinsanity.TwinsanityInterchange.Enumerations;
 using Twinsanity.TwinsanityInterchange.Interfaces;
@@ -47,11 +48,26 @@ namespace Twinsanity.TwinsanityInterchange.Common
 
         public Vector4 Multiply(float value)
         {
-            var resVec = new Vector4();
-            resVec.X = X * value;
-            resVec.Y = Y * value;
-            resVec.Z = Z * value;
-            resVec.W = W * value;
+            var resVec = new Vector4
+            {
+                X = X * value,
+                Y = Y * value,
+                Z = Z * value,
+                W = W * value
+            };
+            return resVec;
+        }
+
+        public Vector4 Divide(float value)
+        {
+            Debug.Assert(Math.Abs(value) > 0.000001f, "Division value can't be 0");
+            var resVec = new Vector4()
+            {
+                X = X / value,
+                Y = Y / value,
+                Z = Z / value,
+                W = W / value
+            };
             return resVec;
         }
 

--- a/TwinTech/TwinsanityInterchange/Common/VertexBlendShape.cs
+++ b/TwinTech/TwinsanityInterchange/Common/VertexBlendShape.cs
@@ -1,7 +1,21 @@
-﻿namespace Twinsanity.TwinsanityInterchange.Common
+﻿using System;
+
+namespace Twinsanity.TwinsanityInterchange.Common
 {
     public class VertexBlendShape
     {
+        public Vector4 GetVector4()
+        {
+            var resultVec = new Vector4();
+            resultVec.SetBinaryX((UInt32)((Int32)(Offset.X / BlendShape.X)));
+            resultVec.SetBinaryY((UInt32)((Int32)(Offset.Y / BlendShape.Y)));
+            resultVec.SetBinaryZ((UInt32)((Int32)(Offset.Z / BlendShape.Z)));
+            resultVec.SetBinaryW(0x0);
+
+            return resultVec;
+        }
+
+        public Vector3 BlendShape { get; set; }
         public Vector4 Offset { get; set; }
     }
 }

--- a/TwinTech/TwinsanityInterchange/Common/VertexJointInfo.cs
+++ b/TwinTech/TwinsanityInterchange/Common/VertexJointInfo.cs
@@ -36,7 +36,7 @@ namespace Twinsanity.TwinsanityInterchange.Common
             v.SetBinaryX(xComp);
             v.SetBinaryY(yComp);
             v.SetBinaryZ(zComp);
-            UInt32 wComp = Connection ? 0 : (0x80U << 8);
+            UInt32 wComp = Connection ? 0 : 0x8000U;
             var weightCount = 1;
             var totalWeight = Weight1 + Weight2;
             if (totalWeight < 1)

--- a/TwinTech/TwinsanityInterchange/Common/VertexJointInfo.cs
+++ b/TwinTech/TwinsanityInterchange/Common/VertexJointInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Twinsanity.TwinsanityInterchange.Enumerations;
 using Twinsanity.TwinsanityInterchange.Interfaces;
@@ -7,39 +8,35 @@ namespace Twinsanity.TwinsanityInterchange.Common
 {
     public class VertexJointInfo : ITwinSerializable
     {
-        public float Weight1;
-        public float Weight2;
-        public float Weight3;
-        public int JointIndex1;
-        public int JointIndex2;
-        public int JointIndex3;
-        public bool Connection;
+        public Single Weight1;
+        public Single Weight2;
+        public Single Weight3;
+        public Int32 JointIndex1;
+        public Int32 JointIndex2;
+        public Int32 JointIndex3;
+        public Boolean Connection;
 
         public Int32 GetLength()
         {
             return Constants.SIZE_VECTOR4;
         }
 
-        public void Read(BinaryReader reader, Int32 length)
+        public Vector4 GetVector4()
         {
-            throw new NotImplementedException();
-        }
-
-        public void Write(BinaryWriter writer)
-        {
+            Debug.Assert(Math.Abs(Weight1 + Weight2 + Weight3 - 1.0f) < 0.000001f, "Weights must sum up to 1");
             Vector4 v = new()
             {
                 X = Weight1,
                 Y = Weight2,
                 Z = Weight3
             };
-            var xComp = v.GetBinaryX() | (uint)(JointIndex1 * 4);
-            var yComp = v.GetBinaryY() | (uint)(JointIndex2 * 4);
-            var zComp = v.GetBinaryZ() | (uint)(JointIndex3 * 4);
+            var xComp = v.GetBinaryX() | (UInt32)(JointIndex1 * 4);
+            var yComp = v.GetBinaryY() | (UInt32)(JointIndex2 * 4);
+            var zComp = v.GetBinaryZ() | (UInt32)(JointIndex3 * 4);
             v.SetBinaryX(xComp);
             v.SetBinaryY(yComp);
             v.SetBinaryZ(zComp);
-            uint wComp = Connection ? 0 : (0x80U << 8);
+            UInt32 wComp = Connection ? 0 : (0x80U << 8);
             var weightCount = 1;
             var totalWeight = Weight1 + Weight2;
             if (totalWeight < 1)
@@ -50,8 +47,19 @@ namespace Twinsanity.TwinsanityInterchange.Common
             {
                 weightCount++;
             }
-            wComp |= (uint)weightCount;
+            wComp |= (UInt32)weightCount;
             v.SetBinaryW(wComp);
+            return v;
+        }
+
+        public void Read(BinaryReader reader, Int32 length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write(BinaryWriter writer)
+        {
+            var v = GetVector4();
             v.Write(writer);
         }
     }

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinFace.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinFace.cs
@@ -75,7 +75,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
             {
                 Vertices.Select(v => v.GetVector4()).ToList()
             };
-            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.BlendFace, data, null);
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelFormat.BlendFace, data, null);
             faceData = compiler.Compile();
 
             writer.Write(faceData.Length << 4);

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinFace.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinFace.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Twinsanity.PS2Hardware;
 using Twinsanity.TwinsanityInterchange.Common;
 using Twinsanity.TwinsanityInterchange.Interfaces.Items.SubItems;
@@ -50,15 +51,16 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
             using var reader = new BinaryReader(ms);
             var interpreter = VIFInterpreter.InterpretCode(reader);
             var data = interpreter.GetMem();
-            Vertices = new((int)VertexesAmount);
+            Vertices = new((Int32)VertexesAmount);
             for (Int32 i = 0; i < VertexesAmount; i++)
             {
                 var vec = data[0][i + 1];
-                var xComp = (int)vec.GetBinaryX();
-                var yComp = (int)vec.GetBinaryY();
-                var zComp = (int)vec.GetBinaryZ();
+                var xComp = (Int32)vec.GetBinaryX();
+                var yComp = (Int32)vec.GetBinaryY();
+                var zComp = (Int32)vec.GetBinaryZ();
                 Vertices.Add(new VertexBlendShape
                 {
+                    BlendShape = blendShape,
                     Offset = new Vector4(xComp * blendShape.X, yComp * blendShape.Y, zComp * blendShape.Z, 1.0f)
                 });
             }
@@ -66,6 +68,16 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
 
         public void Write(BinaryWriter writer)
         {
+            var vertexData = Vertices.Select(v => v.GetVector4()).ToList();
+            // Add pad vertex
+            vertexData.Insert(0, new Vector4());
+            var data = new List<List<Vector4>>()
+            {
+                Vertices.Select(v => v.GetVector4()).ToList()
+            };
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.BlendFace, data, null);
+            faceData = compiler.Compile();
+
             writer.Write(faceData.Length << 4);
             writer.Write(VertexesAmount);
             writer.Write(faceData);

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinModel.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinModel.cs
@@ -160,7 +160,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                 Colors,
                 SkinJoints.Select(j => j.GetVector4()).ToList()
             };
-            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.Skin, data, null);
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelFormat.Skin, data, null);
             vifCode = compiler.Compile();
             VertexesAmount = Vertexes.Count;
             writer.Write(vifCode.Length);

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinModel.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2BlendSkinModel.cs
@@ -51,41 +51,42 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
             Colors = new List<Vector4>();
             SkinJoints = new List<VertexJointInfo>();
 
-            const int VERT_DATA_INDEX = 3;
-            for (int i = 0; i < data.Count;)
+            const Int32 VERT_DATA_INDEX = 3;
+            for (Int32 i = 0; i < data.Count;)
             {
                 var verts = data[i][0].GetBinaryX() & 0xFF;
                 var fields = (data[i + 1][0].GetBinaryX() & 0xFF) / verts;
                 var scaleVec = data[i + 2][0];
-                var vertex_batch_1 = data[i + VERT_DATA_INDEX];
-                var vertex_batch_2 = data[i + VERT_DATA_INDEX + 1];
-                var vertex_batch_3 = data[i + VERT_DATA_INDEX + 3];
-                var vertex_batch_4 = data[i + VERT_DATA_INDEX + 2];
+
+                var positionVertexBatch = data[i + VERT_DATA_INDEX];
+                var uvVertexBatch = data[i + VERT_DATA_INDEX + 1];
+                var jointInfosVertexBatch = data[i + VERT_DATA_INDEX + 3];
+                var colorsVertexBatch = data[i + VERT_DATA_INDEX + 2];
 
                 // Vertex conversion
                 for (int j = 0; j < verts; ++j)
                 {
-                    var v1 = new Vector4(vertex_batch_1[j]);
-                    var v2 = new Vector4(vertex_batch_2[j]);
-                    v1.X = (int)v1.GetBinaryX();
-                    v1.Y = (int)v1.GetBinaryY();
-                    v1.Z = (int)v1.GetBinaryZ();
-                    v1.W = (int)v1.GetBinaryW();
-                    v2.X = (int)v2.GetBinaryX();
-                    v2.Y = (int)v2.GetBinaryY();
-                    v2.Z = (int)v2.GetBinaryZ();
-                    v2.W = (int)v2.GetBinaryW();
+                    var v1 = new Vector4(positionVertexBatch[j]);
+                    var v2 = new Vector4(uvVertexBatch[j]);
+                    v1.X = (Int32)v1.GetBinaryX();
+                    v1.Y = (Int32)v1.GetBinaryY();
+                    v1.Z = (Int32)v1.GetBinaryZ();
+                    v1.W = (Int32)v1.GetBinaryW();
+                    v2.X = (Int32)v2.GetBinaryX();
+                    v2.Y = (Int32)v2.GetBinaryY();
+                    v2.Z = (Int32)v2.GetBinaryZ();
+                    v2.W = (Int32)v2.GetBinaryW();
                     v1 = v1.Multiply(scaleVec.X);
                     v2 = v2.Multiply(scaleVec.Y);
-                    vertex_batch_1[j] = v1;
-                    vertex_batch_2[j] = v2;
+                    positionVertexBatch[j] = v1;
+                    uvVertexBatch[j] = v2;
                 }
 
                 // Convert joints information
                 var jointInfos = new List<VertexJointInfo>();
                 for (int j = 0; j < verts; ++j)
                 {
-                    var v1 = vertex_batch_3[j];
+                    var v1 = jointInfosVertexBatch[j];
 
                     var connValue = v1.GetBinaryW() & 0xFF00;
 
@@ -123,9 +124,9 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                         Weight1 = weight1,
                         Weight2 = weight2,
                         Weight3 = weight3,
-                        JointIndex1 = (int)jointIndex1,
-                        JointIndex2 = (int)jointIndex2,
-                        JointIndex3 = (int)jointIndex3,
+                        JointIndex1 = (Int32)jointIndex1,
+                        JointIndex2 = (Int32)jointIndex2,
+                        JointIndex3 = (Int32)jointIndex3,
                         Connection = connValue >> 8 != 128
                     };
 
@@ -133,15 +134,15 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                 }
 
                 // Save the batches into their respective vertex parts
-                for (int j = 0; j < verts; j++)
+                for (Int32 j = 0; j < verts; j++)
                 {
-                    Vertexes.Add(vertex_batch_1[j]);
-                    UVW.Add(vertex_batch_2[j]);
-                    Colors.Add(vertex_batch_4[j]);
+                    Vertexes.Add(positionVertexBatch[j]);
+                    UVW.Add(uvVertexBatch[j]);
+                    Colors.Add(colorsVertexBatch[j]);
                     SkinJoints.Add(jointInfos[j]);
                 }
 
-                i += (int)fields + 3;
+                i += (Int32)fields + 3;
             }
 
             foreach (var face in Faces)
@@ -152,6 +153,16 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
 
         public void Write(BinaryWriter writer)
         {
+            var data = new List<List<Vector4>>()
+            {
+                Vertexes,
+                UVW,
+                Colors,
+                SkinJoints.Select(j => j.GetVector4()).ToList()
+            };
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.Skin, data, null);
+            vifCode = compiler.Compile();
+            VertexesAmount = Vertexes.Count;
             writer.Write(vifCode.Length);
             writer.Write(VertexesAmount);
             writer.Write(vifCode);

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubModel.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubModel.cs
@@ -12,6 +12,8 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
     {
         private UInt32 VertexesCount { get; set; }
         private Byte[] VertexData { get; set; }
+
+
         public Byte[] UnusedBlob { get; set; }
         public List<Vector4> Vertexes { get; set; }
         public List<Vector4> UVW { get; set; }
@@ -101,10 +103,10 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                         var b = Math.Min(e.GetBinaryZ() & 0xFF, 255);
                         var a = (e.GetBinaryW() & 0xFF) << 1;
 
-                        Color col = new Color((byte)r, (byte)g, (byte)b, (byte)a);
+                        Color col = new((byte)r, (byte)g, (byte)b, (byte)a);
                         Colors.Add(Vector4.FromColor(col));
 
-                        Vector4 uv = new Vector4(e);
+                        Vector4 uv = new(e);
                         uv.SetBinaryX(uv.GetBinaryX() & 0xFFFFFF00);
                         uv.SetBinaryY(uv.GetBinaryY() & 0xFFFFFF00);
                         uv.SetBinaryZ(uv.GetBinaryZ() & 0xFFFFFF00);
@@ -127,7 +129,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                     {
                         if (e == null)
                             break;
-                        Vector4 emit = new Vector4(e);
+                        Vector4 emit = new(e);
                         emit.X = emit.GetBinaryX() & 0xFF;// / 256.0f;
                         emit.Y = emit.GetBinaryY() & 0xFF;// / 256.0f;
                         emit.Z = emit.GetBinaryZ() & 0xFF;// / 256.0f;
@@ -137,29 +139,33 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                 }
                 i += fields + 2;
                 TrimList(UVW, Vertexes.Count);
-                TrimList(EmitColor, Vertexes.Count);
                 TrimList(Colors, Vertexes.Count);
-                TrimList(Normals, Vertexes.Count, new Vector4(0.0f, 0.0f, 0.0f, 1.0f));
             }
         }
         public void Write(BinaryWriter writer)
         {
-            //TODO: uncomment VertixesCount = (UInt32)Vertixes.Count();
-            var unkVec1 = new Vector4();
-            var unkVec2 = new Vector4();
+            VertexesCount = (UInt32)Vertexes.Count;
             TrimList(UVW, (Int32)VertexesCount);
-            TrimList(EmitColor, (Int32)VertexesCount);
-            TrimList(Normals, (Int32)VertexesCount, new Vector4(0.5f, 0.5f, 0.5f, 0.5f));
             TrimList(Colors, (Int32)VertexesCount, new Vector4());
-            var data = new List<List<Vector4>>();
-            data.Add(new List<Vector4>() { unkVec1 });
-            data.Add(new List<Vector4>() { unkVec2 });
-            data.Add(Vertexes);
-            data.Add(UVW);
-            data.Add(Normals);
-            data.Add(EmitColor);
-            data.Add(Colors);
-            //TODO: Pack data to VIF
+            var data = new List<List<Vector4>>
+            {
+                Vertexes,
+                Colors,
+                UVW
+            };
+            // Normals are optional
+            if (Normals.Count == Vertexes.Count)
+            {
+                data.Add(Normals);
+            }
+            // Emit colors are optional
+            if (EmitColor.Count == Vertexes.Count)
+            {
+                data.Add(EmitColor);
+            }
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.Model, data, Connection);
+            VertexData = compiler.Compile();
+
             writer.Write(VertexesCount);
             writer.Write(VertexData.Length);
             writer.Write(VertexData);
@@ -167,7 +173,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
             writer.Write(UnusedBlob);
         }
 
-        private void TrimList(List<Vector4> list, Int32 desiredLength, Vector4 defaultValue = null)
+        private static void TrimList(List<Vector4> list, Int32 desiredLength, Vector4 defaultValue = null)
         {
             if (list != null)
             {

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubModel.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubModel.cs
@@ -163,7 +163,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
             {
                 data.Add(EmitColor);
             }
-            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.Model, data, Connection);
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelFormat.Model, data, Connection);
             VertexData = compiler.Compile();
 
             writer.Write(VertexesCount);

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubSkin.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubSkin.cs
@@ -141,7 +141,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
                 Colors,
                 SkinJoints.Select(j => j.GetVector4()).ToList()
             };
-            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelType.Skin, data, null);
+            var compiler = new TwinVIFCompiler(TwinVIFCompiler.ModelFormat.Skin, data, null);
             VifCode = compiler.Compile();
             writer.Write(Material);
             writer.Write(VifCode.Length);

--- a/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubSkin.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/PS2/Items/SubItems/PS2SubSkin.cs
@@ -134,6 +134,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems
         }
         public void Write(BinaryWriter writer)
         {
+            VertexAmount = Vertexes.Count;
             var data = new List<List<Vector4>>()
             {
                 Vertexes,

--- a/TwinTech/TwinsanityInterchange/Implementations/Xbox/Items/SubItems/XboxSubModel.cs
+++ b/TwinTech/TwinsanityInterchange/Implementations/Xbox/Items/SubItems/XboxSubModel.cs
@@ -20,6 +20,7 @@ namespace Twinsanity.TwinsanityInterchange.Implementations.Xbox.Items.SubItems
         public void CalculateData()
         {
             // Data needs no decompression as it is already presented decompressed on read
+            // TODO: Figure out the indexing
         }
 
         public Int32 GetLength()

--- a/Twinsanity Command Interface/Program.cs
+++ b/Twinsanity Command Interface/Program.cs
@@ -30,6 +30,7 @@ namespace Twinsanity_Command_Interface
                 UV = new Vector3();
                 Normal = new Vector4();
                 EmitColor = new Vector4();
+                JointInfo = new VertexJointInfo();
             }
             public Vertex(Vector4 pos) : this()
             {
@@ -70,6 +71,7 @@ namespace Twinsanity_Command_Interface
             }
             public Vector4 EmitColor { get; set; }
             public Vector3 UV { get; set; }
+            public VertexJointInfo JointInfo { get; set; }
 
             public bool HasNormals { get; private set; }
 
@@ -112,98 +114,224 @@ namespace Twinsanity_Command_Interface
 
         static void Main(string[] args)
         {
-            if (args.Length != 1)
+            if (args.Length != 2)
             {
-                Console.WriteLine("Must provide a path to the model in the format of FBX. Other formats like OBJ and GLTF aren't tested but could work.");
-                Console.WriteLine("Usage: TwinsanityCommandInterface.exe \"C:/Models/TestModel.fbx");
+                Console.WriteLine("Must provide a path to the model in the format of FBX and model type (0 for static models, 1 for rigged models). Other formats like OBJ and GLTF aren't tested but could work.");
+                Console.WriteLine("Usage: TwinsanityCommandInterface.exe \"C:/Models/TestModel.fbx\"");
                 return;
             }
             String modelPath = args[0];
-            var assimp = new AssimpContext();
+            using var assimp = new AssimpContext();
             var scene = assimp.ImportFile(modelPath);
-            List<List<Vertex>> totalVertexes = new();
-            List<List<IndexedFace>> totalFaces = new();
-            PS2AnyModel model = new();
-            foreach (var mesh in scene.Meshes)
+            var modelType = Int32.Parse(args[1]);
+            if (modelType == 0)
             {
-                var submodel = new List<Vertex>();
-                for (Int32 i = 0; i < mesh.VertexCount; i++)
+                List<List<Vertex>> totalVertexes = new();
+                List<List<IndexedFace>> totalFaces = new();
+                PS2AnyModel model = new();
+                foreach (var mesh in scene.Meshes)
                 {
-                    var vertex = new Vertex(
-                        new Vector4(-mesh.Vertices[i].X, mesh.Vertices[i].Y, mesh.Vertices[i].Z, 0.0f),
-                        new Vector4(1f, 1f, 1f, 1f),
-                        new Vector4(mesh.TextureCoordinateChannels[0][i].X, mesh.TextureCoordinateChannels[0][i].Y, 1.0f, 0.0f)
-                        )
+                    var submodel = new List<Vertex>();
+                    for (Int32 i = 0; i < mesh.VertexCount; i++)
                     {
-                        Normal = new Vector4(-mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z, 0f),
-                        EmitColor = new Vector4(1f, 1f, 1f, 1f)
+                        var vertex = new Vertex(
+                            new Vector4(-mesh.Vertices[i].X, mesh.Vertices[i].Y, mesh.Vertices[i].Z, 0.0f),
+                            new Vector4(1f, 1f, 1f, 1f),
+                            new Vector4(mesh.TextureCoordinateChannels[0][i].X, mesh.TextureCoordinateChannels[0][i].Y, 1.0f, 0.0f)
+                            )
+                        {
+                            Normal = new Vector4(-mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z, 0f),
+                            EmitColor = new Vector4(1f, 1f, 1f, 1f)
+                        };
+                        submodel.Add(vertex);
+                    }
+
+                    var faces = new List<IndexedFace>();
+                    for (var i = 0; i < mesh.FaceCount; ++i)
+                    {
+                        faces.Add(new IndexedFace(mesh.Faces[i].Indices.ToArray()));
+                    }
+
+                    totalVertexes.Add(submodel);
+                    totalFaces.Add(faces);
+                }
+
+                var vertexBatchIndex = 0;
+                foreach (var faces in totalFaces)
+                {
+                    var submodel = new PS2SubModel
+                    {
+                        UnusedBlob = Array.Empty<Byte>(),
+                        Vertexes = new(),
+                        UVW = new(),
+                        Colors = new(),
+                        EmitColor = new(),
+                        Normals = new(),
+                        Connection = new()
                     };
-                    submodel.Add(vertex);
+                    var vertexBatch = totalVertexes[vertexBatchIndex++];
+                    var i = 0;
+                    foreach (var face in faces)
+                    {
+                        i %= TwinVIFCompiler.VertexBatchAmount;
+
+                        var idx0 = (i % 2 == 0) ? 0 : 1;
+                        var idx1 = (i % 2 == 0) ? 1 : 0;
+                        submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx0]].Position, 1f));
+                        submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx1]].Position, 1f));
+                        submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[2]].Position, 1f));
+                        submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx0]].UV, 0f));
+                        submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx1]].UV, 0f));
+                        submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[2]].UV, 0f));
+                        submodel.Colors.Add(vertexBatch[face.Indexes[idx0]].Color);
+                        submodel.Colors.Add(vertexBatch[face.Indexes[idx1]].Color);
+                        submodel.Colors.Add(vertexBatch[face.Indexes[2]].Color);
+                        submodel.Normals.Add(vertexBatch[face.Indexes[idx0]].Normal);
+                        submodel.Normals.Add(vertexBatch[face.Indexes[idx1]].Normal);
+                        submodel.Normals.Add(vertexBatch[face.Indexes[2]].Normal);
+                        submodel.EmitColor.Add(vertexBatch[face.Indexes[idx0]].EmitColor);
+                        submodel.EmitColor.Add(vertexBatch[face.Indexes[idx1]].EmitColor);
+                        submodel.EmitColor.Add(vertexBatch[face.Indexes[2]].EmitColor);
+                        submodel.Connection.Add(false);
+                        submodel.Connection.Add(false);
+                        submodel.Connection.Add(true);
+
+                        ++i;
+                    }
+                    model.SubModels.Add(submodel);
                 }
 
-                var faces = new List<IndexedFace>();
-                for (var i = 0; i < mesh.FaceCount; ++i)
-                {
-                    faces.Add(new IndexedFace(mesh.Faces[i].Indices.ToArray()));
-                }
-
-                totalVertexes.Add(submodel);
-                totalFaces.Add(faces);
+                using var ps2Model = File.Create(Directory.GetCurrentDirectory() + "/compiled_ps2_model");
+                using var writer = new BinaryWriter(ps2Model);
+                model.Write(writer);
+                writer.Flush();
+                ps2Model.Flush();
+                writer.Close();
             }
-            assimp.Dispose();
-
-            var vertexBatchIndex = 0;
-            foreach (var faces in totalFaces)
+            else
             {
-                var submodel = new PS2SubModel
-                {
-                    UnusedBlob = Array.Empty<Byte>(),
-                    Vertexes = new(),
-                    UVW = new(),
-                    Colors = new(),
-                    EmitColor = new(),
-                    Normals = new(),
-                    Connection = new()
-                };
-                var vertexBatch = totalVertexes[vertexBatchIndex++];
-                var i = 0;
-                foreach (var face in faces)
-                {
-                    i %= TwinVIFCompiler.VertexBatchAmount;
+                List<List<Vertex>> totalVertexes = new();
+                List<List<IndexedFace>> totalFaces = new();
+                PS2AnySkin skin = new();
 
-                    var idx0 = (i % 2 == 0) ? 0 : 1;
-                    var idx1 = (i % 2 == 0) ? 1 : 0;
-                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx0]].Position, 1f));
-                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx1]].Position, 1f));
-                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[2]].Position, 1f));
-                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx0]].UV, 0f));
-                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx1]].UV, 0f));
-                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[2]].UV, 0f));
-                    submodel.Colors.Add(vertexBatch[face.Indexes[idx0]].Color);
-                    submodel.Colors.Add(vertexBatch[face.Indexes[idx1]].Color);
-                    submodel.Colors.Add(vertexBatch[face.Indexes[2]].Color);
-                    submodel.Normals.Add(vertexBatch[face.Indexes[idx0]].Normal);
-                    submodel.Normals.Add(vertexBatch[face.Indexes[idx1]].Normal);
-                    submodel.Normals.Add(vertexBatch[face.Indexes[2]].Normal);
-                    submodel.EmitColor.Add(vertexBatch[face.Indexes[idx0]].EmitColor);
-                    submodel.EmitColor.Add(vertexBatch[face.Indexes[idx1]].EmitColor);
-                    submodel.EmitColor.Add(vertexBatch[face.Indexes[2]].EmitColor);
-                    submodel.Connection.Add(false);
-                    submodel.Connection.Add(false);
-                    submodel.Connection.Add(true);
+                foreach (var mesh in scene.Meshes)
+                {
+                    var submodel = new List<Vertex>();
 
-                    ++i;
+                    // Convert bone -> vertex index to vertex -> bone id
+                    List<Dictionary<int, Tuple<int, float>>> vertexToBone = new();
+                    for (Int32 i = 0; i < mesh.Bones.Count; i++)
+                    {
+                        var bone = mesh.Bones[i];
+                        vertexToBone.Add(new());
+                        foreach (var vertexWeight in bone.VertexWeights)
+                        {
+                            vertexToBone[^1].Add(vertexWeight.VertexID, new(i, vertexWeight.Weight));
+                        }
+                    }
+
+                    for (Int32 i = 0; i < mesh.VertexCount; i++)
+                    {
+                        var vertex = new Vertex(
+                            new Vector4(-mesh.Vertices[i].X, mesh.Vertices[i].Y, mesh.Vertices[i].Z, 0.0f),
+                            new Vector4(1f, 1f, 1f, 1f),
+                            new Vector4(mesh.TextureCoordinateChannels[0][i].X, mesh.TextureCoordinateChannels[0][i].Y, 1.0f, 0.0f)
+                            )
+                        {
+                            JointInfo = new VertexJointInfo()
+                            {
+                                Connection = false
+                            }
+                        };
+
+                        List<Tuple<int, float>> joints = new();
+                        foreach (var vertexMap in vertexToBone)
+                        {
+                            if (vertexMap.ContainsKey(i))
+                            {
+                                joints.Add(vertexMap[i]);
+                            }
+                        }
+                        if (joints.Count == 0)
+                        {
+                            Console.WriteLine("Vertex must be connected to at least 1 joint");
+                            return;
+                        }
+                        if (joints.Count > 3)
+                        {
+                            Console.WriteLine("Vertex can only have up to 3 joints connected to it");
+                            return;
+                        }
+                        vertex.JointInfo.JointIndex1 = joints[0].Item1;
+                        vertex.JointInfo.Weight1 = joints[0].Item2;
+                        if (joints.Count >= 2)
+                        {
+                            vertex.JointInfo.JointIndex2 = joints[1].Item1;
+                            vertex.JointInfo.Weight2 = joints[1].Item2;
+                        }
+                        if (joints.Count == 3)
+                        {
+                            vertex.JointInfo.JointIndex3 = joints[2].Item1;
+                            vertex.JointInfo.Weight3 = joints[2].Item2;
+                        }
+                        submodel.Add(vertex);
+                    }
+
+                    var faces = new List<IndexedFace>();
+                    for (var i = 0; i < mesh.FaceCount; ++i)
+                    {
+                        faces.Add(new IndexedFace(mesh.Faces[i].Indices.ToArray()));
+                    }
+
+                    totalVertexes.Add(submodel);
+                    totalFaces.Add(faces);
                 }
-                model.SubModels.Add(submodel);
+
+                var vertexBatchIndex = 0;
+                foreach (var faces in totalFaces)
+                {
+                    var subskin = new PS2SubSkin
+                    {
+                        Vertexes = new(),
+                        UVW = new(),
+                        Colors = new(),
+                        SkinJoints = new(),
+                        Material = 0xB37BBFB3,
+                    };
+                    var vertexBatch = totalVertexes[vertexBatchIndex++];
+                    var i = 0;
+                    foreach (var face in faces)
+                    {
+                        i %= TwinVIFCompiler.VertexBatchAmount;
+
+                        var idx0 = (i % 2 == 0) ? 0 : 1;
+                        var idx1 = (i % 2 == 0) ? 1 : 0;
+                        subskin.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx0]].Position, 1f));
+                        subskin.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx1]].Position, 1f));
+                        subskin.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[2]].Position, 1f));
+                        subskin.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx0]].UV, 0f));
+                        subskin.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx1]].UV, 0f));
+                        subskin.UVW.Add(new Vector4(vertexBatch[face.Indexes[2]].UV, 0f));
+                        subskin.Colors.Add(vertexBatch[face.Indexes[idx0]].Color);
+                        subskin.Colors.Add(vertexBatch[face.Indexes[idx1]].Color);
+                        subskin.Colors.Add(vertexBatch[face.Indexes[2]].Color);
+                        subskin.SkinJoints.Add(vertexBatch[face.Indexes[idx0]].JointInfo);
+                        subskin.SkinJoints.Add(vertexBatch[face.Indexes[idx1]].JointInfo);
+                        vertexBatch[face.Indexes[2]].JointInfo.Connection = true;
+                        subskin.SkinJoints.Add(vertexBatch[face.Indexes[2]].JointInfo);
+
+                        ++i;
+                    }
+                    skin.SubSkins.Add(subskin);
+                }
+
+                using var ps2Skin = File.Create(Directory.GetCurrentDirectory() + "/compiled_ps2_skin");
+                using var writer = new BinaryWriter(ps2Skin);
+                skin.Write(writer);
+                writer.Flush();
+                ps2Skin.Flush();
+                writer.Close();
             }
-
-            using var ps2Model = File.Create(Directory.GetCurrentDirectory() + "/compiled_ps2_model");
-            using var writer = new BinaryWriter(ps2Model);
-            model.Write(writer);
-            writer.Flush();
-            ps2Model.Flush();
-            writer.Close();
-
         }
     }
 }

--- a/Twinsanity Command Interface/Program.cs
+++ b/Twinsanity Command Interface/Program.cs
@@ -111,6 +111,12 @@ namespace Twinsanity_Command_Interface
 
         static void Main(string[] args)
         {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Must provide a path to the model in the format of FBX. Other formats like OBJ and GLTF aren't tested but could work.");
+                Console.WriteLine("Usage: TwinsanityCommandInterface.exe \"C:/Models/TestModel.fbx");
+                return;
+            }
             String modelPath = args[0];
             var assimp = new AssimpContext();
             var scene = assimp.ImportFile(modelPath);
@@ -178,13 +184,11 @@ namespace Twinsanity_Command_Interface
                     submodel.EmitColor.Add(vertexBatch[face.Indexes[idx0]].EmitColor);
                     submodel.EmitColor.Add(vertexBatch[face.Indexes[idx1]].EmitColor);
                     submodel.EmitColor.Add(vertexBatch[face.Indexes[2]].EmitColor);
-              
-                    ++i;  
-                    // What do?
-
                     submodel.Connection.Add(false);
                     submodel.Connection.Add(false);
                     submodel.Connection.Add(true);
+
+                    ++i;
                 }
                 model.SubModels.Add(submodel);
             }

--- a/Twinsanity Command Interface/Program.cs
+++ b/Twinsanity Command Interface/Program.cs
@@ -1,12 +1,17 @@
-﻿using System;
+﻿using Assimp;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Twinsanity.TwinsanityInterchange.Common;
 using Twinsanity.TwinsanityInterchange.Enumerations;
 using Twinsanity.TwinsanityInterchange.Implementations.Base;
 using Twinsanity.TwinsanityInterchange.Implementations.PS2;
 using Twinsanity.TwinsanityInterchange.Implementations.PS2.Archives;
 using Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.Graphics;
+using Twinsanity.TwinsanityInterchange.Implementations.PS2.Items.SubItems;
 using Twinsanity.TwinsanityInterchange.Implementations.PS2.Sections;
 using Twinsanity.TwinsanityInterchange.Implementations.PS2.Sections.Graphics;
 using Twinsanity.TwinsanityInterchange.Interfaces;
@@ -53,9 +58,21 @@ namespace Twinsanity_Command_Interface
             }
             public Vector3 Position { get; set; }
             public Vector4 Color { get; set; }
-            public Vector4 Normal { get; set; }
+            public Vector4 Normal
+            {
+                get => _normal;
+                set
+                {
+                    _normal = value;
+                    HasNormals = true;
+                }
+            }
             public Vector4 EmitColor { get; set; }
             public Vector3 UV { get; set; }
+
+            public bool HasNormals { get; private set; }
+
+            private Vector4 _normal;
 
             public override String ToString()
             {
@@ -67,247 +84,112 @@ namespace Twinsanity_Command_Interface
             }
         }
 
+        private class IndexedFace
+        {
+            public Int32[] Indexes { get; set; }
+            public IndexedFace()
+            {
+                Indexes = null;
+            }
+            public IndexedFace(Int32[] indexes)
+            {
+                Indexes = indexes;
+            }
+            public override String ToString()
+            {
+                Debug.Assert(Indexes != null, "Indexes must be created at this point of time");
+
+                StringBuilder builder = new();
+                builder.Append(Indexes.Length);
+                foreach (var index in Indexes)
+                {
+                    builder.Append($" {index}");
+                }
+                return builder.ToString();
+            }
+        }
+
         static void Main(string[] args)
         {
-            String readArchives = args[0];
-            String testPath = args[1];
-            String testSavePath = args[2];
-            if (readArchives == "Y")
+            String modelPath = args[0];
+            var assimp = new AssimpContext();
+            var scene = assimp.ImportFile(modelPath);
+            List<List<Vertex>> totalVertexes = new();
+            List<List<IndexedFace>> totalFaces = new();
+            PS2AnyModel model = new();
+            foreach (var mesh in scene.Meshes)
             {
-                testPath += @"\Crash6\";
-                String[] archivePaths = System.IO.Directory.GetFiles(testPath, "*.BD", System.IO.SearchOption.TopDirectoryOnly);
-                archivePaths = archivePaths.Concat(System.IO.Directory.GetFiles(testPath, "*.MB", System.IO.SearchOption.TopDirectoryOnly)).ToArray();
-                List<ITwinSerializable> archives = new List<ITwinSerializable>();
-                foreach (var path in archivePaths)
+                var submodel = new List<Vertex>();
+                for (Int32 i = 0; i < mesh.VertexCount; i++)
                 {
-                    var headerPath = String.Empty;
-                    ITwinSerializable archive = null;
-                    if (path.EndsWith("MB") || path.EndsWith("mb"))
+                    var vertex = new Vertex(
+                        new Vector4(-mesh.Vertices[i].X, mesh.Vertices[i].Y, mesh.Vertices[i].Z, 0.0f),
+                        new Vector4(1f, 1f, 1f, 1f),
+                        new Vector4(mesh.TextureCoordinateChannels[0][i].X, mesh.TextureCoordinateChannels[0][i].Y, 1.0f, 0.0f)
+                        )
                     {
-                        headerPath = path.Replace(".MB", ".MH");
-                        if (headerPath == path)
-                        {
-                            headerPath = path.Replace(".mb", ".mh");
-                        }
-                        archive = new PS2MB(headerPath, System.IO.Path.Combine(testSavePath, System.IO.Path.GetFileName(headerPath)));
-                    }
-                    else if (path.EndsWith("BD"))
-                    {
-                        headerPath = path.Replace(".BD", ".BH");
-                        archive = new PS2BD(headerPath, System.IO.Path.Combine(testSavePath, System.IO.Path.GetFileName(headerPath)));
-                    }
-                    using (System.IO.FileStream stream = new System.IO.FileStream(path, System.IO.FileMode.Open, System.IO.FileAccess.Read))
-                    using (System.IO.BinaryReader reader = new System.IO.BinaryReader(stream))
-                    {
-                        archive.Read(reader, (Int32)reader.BaseStream.Length);
-                        archives.Add(archive);
-                    }
-                    using (System.IO.FileStream stream = new System.IO.FileStream(System.IO.Path.Combine(testSavePath, System.IO.Path.GetFileName(path)),
-                        System.IO.FileMode.Create, System.IO.FileAccess.Write))
-                    using (System.IO.BinaryWriter writer = new System.IO.BinaryWriter(stream))
-                    {
-                        archive.Write(writer);
-                    }
+                        Normal = new Vector4(-mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z, 0f)
+                    };
+                    submodel.Add(vertex);
                 }
-                Console.WriteLine("Done");
+
+                var faces = new List<IndexedFace>();
+                for (var i = 0; i < mesh.FaceCount; ++i)
+                {
+                    faces.Add(new IndexedFace(mesh.Faces[i].Indices.ToArray()));
+                }
+
+                totalVertexes.Add(submodel);
+                totalFaces.Add(faces);
             }
-            else
+            assimp.Dispose();
+
+            var vertexBatchIndex = 0;
+            foreach (var faces in totalFaces)
             {
-                String[] levelsPaths = System.IO.Directory.GetFiles(testPath, "*.rm2", System.IO.SearchOption.AllDirectories);
-                levelsPaths = levelsPaths.Concat(System.IO.Directory.GetFiles(testPath, "*.sm2", System.IO.SearchOption.AllDirectories)).ToArray();
-                List<ITwinSection> levels = new List<ITwinSection>();
-                foreach (String levelPath in levelsPaths)
+                var submodel = new PS2SubModel
                 {
-                    ITwinSection twinLevel = null;
-                    if (levelPath.EndsWith("Default.rm2"))
-                    {
-                        twinLevel = new PS2Default();
-                    }
-                    else if (levelPath.EndsWith("rm2"))
-                    {
-                        twinLevel = new PS2AnyTwinsanityRM2();
-                    }
-                    else if (levelPath.EndsWith("sm2"))
-                    {
-                        twinLevel = new PS2AnyTwinsanitySM2();
-                    }
-                    else
-                    {
-                        twinLevel = new BaseTwinSection();
-                    }
-                    using (System.IO.FileStream stream = new System.IO.FileStream(levelPath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
-                    using (System.IO.BinaryReader reader = new System.IO.BinaryReader(stream))
-                    {
-                        twinLevel.Read(reader, (Int32)reader.BaseStream.Length);
-                        levels.Add(twinLevel);
-                    }
-                    if (twinLevel is PS2AnyTwinsanityRM2)
-                    {
-                        if (!System.IO.Directory.Exists(System.IO.Path.Combine(testSavePath, "skins")))
-                        {
-                            System.IO.Directory.CreateDirectory(System.IO.Path.Combine(testSavePath, "skins"));
-                        }
-                        var graph = twinLevel.GetItem<PS2AnyGraphicsSection>(Constants.LEVEL_GRAPHICS_SECTION).GetItem<PS2AnySkinsSection>(Constants.GRAPHICS_SKINS_SECTION);
-                        for (var i = 0; i < graph.GetItemsAmount(); ++i)
-                        {
-                            var skin = graph.GetItem(i) as PS2AnySkin;
-                            var Vertexes = new List<List<Vertex>>();
-                            var Faces = new List<List<int[]>>();
-                            //var SubBlendIndex = new List<int>();
-                            var refIndex = 0;
-                            var offset = 0;
-                            var fullSkinData = new List<List<Vector4>>();
-                            //var subIndex = 0;
-                            foreach (var e in skin.SubSkins)
-                            {
-                                var vertList = new List<Vertex>();
-                                var faceList = new List<int[]>();
-                                refIndex = 0;
-                                try
-                                {
-                                    e.CalculateData();
-                                }
-                                catch (NullReferenceException ex)
-                                {
-                                    Console.WriteLine($"Failed to calculate blend skin vertex data for skin {skin.GetID():x}: {ex.Message}");
-                                    fullSkinData.Clear();
-                                    break;
-                                }
-
-                                //foreach (var list in e.Vertexes)
-                                {
-                                    //fullSkinData.Add(e.DecompressedData);
-                                }
-                                /*for (var j = 0; j < e.Vertexes.Count; ++j)
-                                {
-                                    if (j < e.Vertexes.Count - 2)
-                                    {
-                                        if (e.Connection[j + 2])
-                                        {
-                                            if ((offset + j) % 2 == 0)
-                                            {
-                                                faceList.Add(new int[] { refIndex, refIndex + 1, refIndex + 2 });
-                                            }
-                                            else
-                                            {
-                                                faceList.Add(new int[] { refIndex + 1, refIndex, refIndex + 2 });
-                                            }
-                                        }
-                                        ++refIndex;
-                                    }
-                                    vertList.Add(new Vertex(e.Vertexes[j], e.Normals[j], e.UVW[j], e.EmitColor[j]));
-                                }
-                                Vertexes.Add(vertList);
-                                Faces.Add(faceList);
-                                offset += e.Vertexes.Count;
-                                refIndex += 2;*/
-                                //SubBlendIndex.Add(subIndex);
-                            }
-                            var skinPath = System.IO.Path.Combine(System.IO.Path.Combine(testSavePath, "skins"), skin.GetName()) + ".bin";
-                            using (System.IO.FileStream skinFile = new System.IO.FileStream(skinPath, System.IO.FileMode.Create, System.IO.FileAccess.Write))
-                            {
-                                foreach (var list in fullSkinData)
-                                {
-                                    foreach (var v in list)
-                                    {
-                                        if (v == null)
-                                            break;
-                                        skinFile.Write(BitConverter.GetBytes(v.GetBinaryX()));
-                                        skinFile.Write(BitConverter.GetBytes(v.GetBinaryY()));
-                                        skinFile.Write(BitConverter.GetBytes(v.GetBinaryZ()));
-                                        skinFile.Write(BitConverter.GetBytes(v.GetBinaryW()));
-                                    }
-                                }
-                            }
-                            // Import
-                            /*Scene scene = new Scene
-                            {
-                                RootNode = new Node("Root")
-                            };*/
-
-                            for (var j = 0; j < Vertexes.Count; ++j)
-                            {
-                                /*var submodel = Vertexes[j];
-                                var faces = Faces[j];
-                                Mesh mesh = new Mesh(PrimitiveType.Triangle);
-                                foreach (var ver in submodel)
-                                {
-                                    var pos = new Vector4(ver.Position.X, ver.Position.Y, ver.Position.Z, 1.0f);
-                                    var adjustment = ver.Color;
-                                    var emCol = ver.EmitColor;
-                                    var uv = ver.UV;
-                                    mesh.Vertices.Add(new Vector3D(pos.X, pos.Y, pos.Z));
-                                    mesh.VertexColorChannels[0].Add(new Color4D(emCol.X, emCol.Y, emCol.Z, emCol.W));
-                                    mesh.TextureCoordinateChannels[0].Add(new Vector3D(uv.X, uv.Y, 1.0f));
-                                }
-                                foreach (var face in faces)
-                                {
-                                    mesh.Faces.Add(new Face(new int[] { face[0], face[1], face[2] }));
-                                }
-                                mesh.MaterialIndex = 0;
-                                scene.Meshes.Add(mesh);
-                                scene.RootNode.MeshIndices.Add(j);*/
-
-                                /*var graphSec = twinLevel.GetItem<PS2AnyGraphicsSection>(Constants.LEVEL_GRAPHICS_SECTION);
-                                var twinMat = graphSec.GetItem<PS2AnyMaterialsSection>(Constants.GRAPHICS_MATERIALS_SECTION).GetItem<PS2AnyMaterial>(skin.SubBlends[SubBlendIndex[j]].Material);
-                                if (twinMat.Shaders[0].TxtMapping != TwinShader.TextureMapping.OFF)
-                                {
-                                    var twinTex = graphSec.GetItem<PS2AnyTexturesSection>(Constants.GRAPHICS_TEXTURES_SECTION).GetItem<PS2AnyTexture>(twinMat.Shaders[0].TextureId);
-                                    twinTex.CalculateData();
-                                    Int32 width = (Int32)Math.Pow(2, twinTex.ImageWidthPower);
-                                    Int32 height = (Int32)Math.Pow(2, twinTex.ImageHeightPower);
-
-                                    var Bits = new UInt32[width * height];
-                                    var BitsHandle = GCHandle.Alloc(Bits, GCHandleType.Pinned);
-                                    var tmpBmp = new Bitmap(width, height, width * 4, System.Drawing.Imaging.PixelFormat.Format32bppPArgb, BitsHandle.AddrOfPinnedObject());
-
-                                    for (var x = 0; x < width; ++x)
-                                    {
-                                        for (var y = 0; y < height; ++y)
-                                        {
-                                            var dstx = x;
-                                            var dsty = height - 1 - y;
-                                            Bits[dstx + dsty * width] = twinTex.Colors[x + y * width].ToARGB();
-                                        }
-                                    }
-
-                                    var bmp = new Bitmap(tmpBmp);
-                                    var texturePath = System.IO.Path.Combine(System.IO.Path.Combine(testSavePath, "skins"), skin.GetName()) + $"{j}.png";
-                                    bmp.Save(texturePath, System.Drawing.Imaging.ImageFormat.Png);
-                                    tmpBmp.Dispose();
-                                    BitsHandle.Free();
-
-                                    Material mat = new Material
-                                    {
-                                        Name = twinMat.Name
-                                    };
-                                    mat.PBR.TextureBaseColor = new TextureSlot(texturePath, TextureType.BaseColor, j, TextureMapping.FromUV, 0, 1.0f,
-                                            TextureOperation.Multiply, TextureWrapMode.Wrap, TextureWrapMode.Wrap, 0);
-                                    scene.Materials.Add(mat);
-                                }*/
-
-                            }
-
-                            /*Material mat = new Material
-                            {
-                                Name = "Default"
-                            };
-
-                            scene.Materials.Add(mat);
-
-                            AssimpContext context = new AssimpContext();
-                            var dataPath = System.IO.Path.Combine(System.IO.Path.Combine(testSavePath, "models"), skin.GetName()) + ".dae";
-                            context.ExportFile(scene, dataPath, "collada");*/
-                        }
-                    }
-                    using (System.IO.FileStream stream = new System.IO.FileStream(System.IO.Path.Combine(testSavePath, System.IO.Path.GetFileName(levelPath)),
-                        System.IO.FileMode.Create, System.IO.FileAccess.Write))
-                    using (System.IO.BinaryWriter writer = new System.IO.BinaryWriter(stream))
-                    {
-                        twinLevel.Write(writer);
-                    }
+                    UnusedBlob = Array.Empty<Byte>(),
+                    Vertexes = new(),
+                    UVW = new(),
+                    Colors = new(),
+                    EmitColor = new(),
+                    Normals = new(),
+                    Connection = new()
+                };
+                var vertexBatch = totalVertexes[vertexBatchIndex++];
+                foreach (var face in faces)
+                {
+                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[0]].Position, 1f));
+                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[1]].Position, 1f));
+                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[2]].Position, 1f));
+                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[0]].UV, 0f));
+                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[1]].UV, 0f));
+                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[2]].UV, 0f));
+                    submodel.Colors.Add(vertexBatch[face.Indexes[0]].Color);
+                    submodel.Colors.Add(vertexBatch[face.Indexes[1]].Color);
+                    submodel.Colors.Add(vertexBatch[face.Indexes[2]].Color);
+                    submodel.Normals.Add(vertexBatch[face.Indexes[0]].Normal);
+                    submodel.Normals.Add(vertexBatch[face.Indexes[1]].Normal);
+                    submodel.Normals.Add(vertexBatch[face.Indexes[2]].Normal);
+                    submodel.EmitColor.Add(vertexBatch[face.Indexes[0]].EmitColor);
+                    submodel.EmitColor.Add(vertexBatch[face.Indexes[1]].EmitColor);
+                    submodel.EmitColor.Add(vertexBatch[face.Indexes[2]].EmitColor);
+                    // What do?
+                    submodel.Connection.Add(false);
+                    submodel.Connection.Add(false);
+                    submodel.Connection.Add(true);
                 }
+                model.SubModels.Add(submodel);
             }
+
+            using var ps2Model = File.Create(Directory.GetCurrentDirectory() + "/compiled_ps2_model");
+            using var writer = new BinaryWriter(ps2Model);
+            model.Write(writer);
+            writer.Flush();
+            ps2Model.Flush();
+            writer.Close();
+
         }
     }
 }

--- a/Twinsanity Command Interface/Program.cs
+++ b/Twinsanity Command Interface/Program.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Twinsanity.PS2Hardware;
 using Twinsanity.TwinsanityInterchange.Common;
 using Twinsanity.TwinsanityInterchange.Enumerations;
 using Twinsanity.TwinsanityInterchange.Implementations.Base;
@@ -134,7 +135,8 @@ namespace Twinsanity_Command_Interface
                         new Vector4(mesh.TextureCoordinateChannels[0][i].X, mesh.TextureCoordinateChannels[0][i].Y, 1.0f, 0.0f)
                         )
                     {
-                        Normal = new Vector4(-mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z, 0f)
+                        Normal = new Vector4(-mesh.Normals[i].X, mesh.Normals[i].Y, mesh.Normals[i].Z, 0f),
+                        EmitColor = new Vector4(1f, 1f, 1f, 1f)
                     };
                     submodel.Add(vertex);
                 }
@@ -167,6 +169,8 @@ namespace Twinsanity_Command_Interface
                 var i = 0;
                 foreach (var face in faces)
                 {
+                    i %= TwinVIFCompiler.VertexBatchAmount;
+
                     var idx0 = (i % 2 == 0) ? 0 : 1;
                     var idx1 = (i % 2 == 0) ? 1 : 0;
                     submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx0]].Position, 1f));

--- a/Twinsanity Command Interface/Program.cs
+++ b/Twinsanity Command Interface/Program.cs
@@ -158,24 +158,30 @@ namespace Twinsanity_Command_Interface
                     Connection = new()
                 };
                 var vertexBatch = totalVertexes[vertexBatchIndex++];
+                var i = 0;
                 foreach (var face in faces)
                 {
-                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[0]].Position, 1f));
-                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[1]].Position, 1f));
+                    var idx0 = (i % 2 == 0) ? 0 : 1;
+                    var idx1 = (i % 2 == 0) ? 1 : 0;
+                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx0]].Position, 1f));
+                    submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[idx1]].Position, 1f));
                     submodel.Vertexes.Add(new Vector4(vertexBatch[face.Indexes[2]].Position, 1f));
-                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[0]].UV, 0f));
-                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[1]].UV, 0f));
+                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx0]].UV, 0f));
+                    submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[idx1]].UV, 0f));
                     submodel.UVW.Add(new Vector4(vertexBatch[face.Indexes[2]].UV, 0f));
-                    submodel.Colors.Add(vertexBatch[face.Indexes[0]].Color);
-                    submodel.Colors.Add(vertexBatch[face.Indexes[1]].Color);
+                    submodel.Colors.Add(vertexBatch[face.Indexes[idx0]].Color);
+                    submodel.Colors.Add(vertexBatch[face.Indexes[idx1]].Color);
                     submodel.Colors.Add(vertexBatch[face.Indexes[2]].Color);
-                    submodel.Normals.Add(vertexBatch[face.Indexes[0]].Normal);
-                    submodel.Normals.Add(vertexBatch[face.Indexes[1]].Normal);
+                    submodel.Normals.Add(vertexBatch[face.Indexes[idx0]].Normal);
+                    submodel.Normals.Add(vertexBatch[face.Indexes[idx1]].Normal);
                     submodel.Normals.Add(vertexBatch[face.Indexes[2]].Normal);
-                    submodel.EmitColor.Add(vertexBatch[face.Indexes[0]].EmitColor);
-                    submodel.EmitColor.Add(vertexBatch[face.Indexes[1]].EmitColor);
+                    submodel.EmitColor.Add(vertexBatch[face.Indexes[idx0]].EmitColor);
+                    submodel.EmitColor.Add(vertexBatch[face.Indexes[idx1]].EmitColor);
                     submodel.EmitColor.Add(vertexBatch[face.Indexes[2]].EmitColor);
+              
+                    ++i;  
                     // What do?
+
                     submodel.Connection.Add(false);
                     submodel.Connection.Add(false);
                     submodel.Connection.Add(true);


### PR DESCRIPTION
Add VIF compiler for PS2 models to allow conversion from general 3D model formats into Twinsanity's models, rigged models and facially rigged models